### PR TITLE
Refactor slides

### DIFF
--- a/src/API.md
+++ b/src/API.md
@@ -18,6 +18,8 @@
     * [new Magpie()](#new_Magpie_new)
     * [.validators](#Magpie+validators) : <code>object</code>
     * [.v](#Magpie+v) : <code>object</code>
+    * [.measurements](#Magpie+measurements) : <code>object</code>
+    * [.validateMeasurements](#Magpie+validateMeasurements) : <code>object</code>
     * [.id](#Magpie+id) : <code>string</code>
     * [.serverUrl](#Magpie+serverUrl) : <code>string</code>
     * [.submissionUrl](#Magpie+submissionUrl) : <code>string</code>
@@ -27,7 +29,9 @@
     * [.contactEmail](#Magpie+contactEmail) : <code>boolean</code>
     * [.socket](#Magpie+socket) : [<code>Socket</code>](#Socket)
     * [.mousetracking](#Magpie+mousetracking) : [<code>Mousetracking</code>](#Mousetracking)
+    * [.nextSlide(index)](#Magpie+nextSlide)
     * [.nextScreen(index)](#Magpie+nextScreen)
+    * [.saveAndNextScreen(index)](#Magpie+saveAndNextScreen)
     * [.addTrialData(data)](#Magpie+addTrialData)
     * [.addExpData(data)](#Magpie+addExpData)
     * [.submit()](#Magpie+submit) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -49,6 +53,19 @@ Gives easy access to validators. Validation is based on [vuelidate](https://vuel
 
 ### magpie.v : <code>object</code>
 Shorthand for $magpie.validators
+
+**Kind**: instance property of [<code>Magpie</code>](#Magpie)  
+<a name="Magpie+measurements"></a>
+
+### magpie.measurements : <code>object</code>
+The measurements of the current screen. All data in this object
+can be saved using $magpie.saveMeasurements
+
+**Kind**: instance property of [<code>Magpie</code>](#Magpie)  
+<a name="Magpie+validateMeasurements"></a>
+
+### magpie.validateMeasurements : <code>object</code>
+Validation results on the current measurements
 
 **Kind**: instance property of [<code>Magpie</code>](#Magpie)  
 <a name="Magpie+id"></a>
@@ -89,10 +106,34 @@ The ID of the experiment
 
 ### magpie.mousetracking : [<code>Mousetracking</code>](#Mousetracking)
 **Kind**: instance property of [<code>Magpie</code>](#Magpie)  
+<a name="Magpie+nextSlide"></a>
+
+### magpie.nextSlide(index)
+Go to the next slide.
+
+**Kind**: instance method of [<code>Magpie</code>](#Magpie)  
+**Access**: public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| index | <code>int</code> | the index of the slide to go to (optional; default is next slide) |
+
 <a name="Magpie+nextScreen"></a>
 
 ### magpie.nextScreen(index)
 Go to the next screen. (Will also reset scroll position.)
+
+**Kind**: instance method of [<code>Magpie</code>](#Magpie)  
+**Access**: public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| index | <code>int</code> | the index of the screen to go to (optional; default is next screen) |
+
+<a name="Magpie+saveAndNextScreen"></a>
+
+### magpie.saveAndNextScreen(index)
+SaveMeasurements and go to the next screen. (Will also reset scroll position.)
 
 **Kind**: instance method of [<code>Magpie</code>](#Magpie)  
 **Access**: public  
@@ -162,6 +203,9 @@ Will display a progress bar if it's not visible, yet.
     * [.participantId](#Socket+participantId) : <code>&#x27;CONNECTING&#x27;</code> \| <code>&#x27;CONNECTED&#x27;</code> \| <code>&#x27;WAITING&#x27;</code> \| <code>&#x27;READY&#x27;</code> \| <code>&#x27;ERROR&#x27;</code>
     * [.participants](#Socket+participants) : <code>Array.&lt;string&gt;</code>
     * [.active](#Socket+active) : <code>Array.&lt;string&gt;</code>
+    * [.active](#Socket+active) : <code>Number</code>
+    * [.active](#Socket+active) : <code>Number</code>
+    * [.active](#Socket+active) : <code>Number</code>
     * [.getParticipantName(id)](#Socket+getParticipantName) ⇒ <code>String</code>
     * [.getParticipantColor(id)](#Socket+getParticipantColor) ⇒ <code>String</code>
     * [.initialize()](#Socket+initialize)
@@ -191,6 +235,24 @@ A reactive list of online participants
 
 ### socket.active : <code>Array.&lt;string&gt;</code>
 A reactive list of participants currently active in the current screen
+
+**Kind**: instance property of [<code>Socket</code>](#Socket)  
+<a name="Socket+active"></a>
+
+### socket.active : <code>Number</code>
+The variant number of this session
+
+**Kind**: instance property of [<code>Socket</code>](#Socket)  
+<a name="Socket+active"></a>
+
+### socket.active : <code>Number</code>
+The chain number of this session
+
+**Kind**: instance property of [<code>Socket</code>](#Socket)  
+<a name="Socket+active"></a>
+
+### socket.active : <code>Number</code>
+The realization number of this session
 
 **Kind**: instance property of [<code>Socket</code>](#Socket)  
 <a name="Socket+getParticipantName"></a>

--- a/src/Magpie.js
+++ b/src/Magpie.js
@@ -37,6 +37,29 @@ export default class Magpie extends EventEmitter {
     return validators;
   }
 
+  /**
+   * The measurements of the current screen. All data in this object
+   * can be saved using $magpie.saveMeasurements
+   * @instance
+   * @member measurements
+   * @memberOf Magpie
+   * @type {object}
+   */
+  get measurements() {
+    return this.experiment.currentScreenComponent.measurements;
+  }
+
+  /**
+   * Validation results on the current measurements
+   * @instance
+   * @member validateMeasurements
+   * @memberOf Magpie
+   * @type {object}
+   */
+  get validateMeasurements() {
+    return this.experiment.currentScreenComponent.$v.measurements;
+  }
+
   constructor(experiment, options) {
     super();
 
@@ -148,6 +171,17 @@ export default class Magpie extends EventEmitter {
   }
 
   /**
+   * Go to the next slide.
+   * @instance
+   * @memberOf Magpie
+   * @public
+   * @param index{int} the index of the slide to go to (optional; default is next slide)
+   */
+  nextSlide(...params) {
+    this.experiment.currentScreenComponent.nextSlide(...params);
+  }
+
+  /**
    * Go to the next screen. (Will also reset scroll position.)
    * @instance
    * @memberOf Magpie
@@ -156,6 +190,18 @@ export default class Magpie extends EventEmitter {
    */
   nextScreen(...params) {
     this.experiment.nextScreen(...params);
+  }
+
+  /**
+   * SaveMeasurements and go to the next screen. (Will also reset scroll position.)
+   * @instance
+   * @memberOf Magpie
+   * @public
+   * @param index{int} the index of the screen to go to (optional; default is next screen)
+   */
+  saveAndNextScreen(index) {
+    this.saveMeasurements();
+    this.nextScreen(index);
   }
 
   /**
@@ -185,6 +231,10 @@ export default class Magpie extends EventEmitter {
    */
   addExpData(data) {
     Object.assign(this.expData, data);
+  }
+
+  saveMeasurements() {
+    this.addTrialData({ ...this.measurements });
   }
 
   onSocketError(er) {

--- a/src/components/Experiment.vue
+++ b/src/components/Experiment.vue
@@ -6,7 +6,6 @@ For every source of trial data you can provide a label and an array. Later you w
 
 ```vue
 <Experiment>
-  <template #screens>
 
     <Screen>
       blue
@@ -22,7 +21,6 @@ For every source of trial data you can provide a label and an array. Later you w
       yellow
     </Screen>
 
-  </template>
 </Experiment>
 ```
 
@@ -30,16 +28,14 @@ For every source of trial data you can provide a label and an array. Later you w
 
 ```vue
 <Experiment>
-  <template #screens>
 
     <Screen v-for="(color, i) in ['blue', 'green', 'yellow']" :key="i">
-      <template #0="{nextScreen}">
+      <Slide>
         Screen {{i}}: {{ color }}
-        <button @click="nextScreen()">next</button>
-      </template>
+        <button @click="$magpie.nextScreen()">next</button>
+      </Slide>
     </Screen>
 
-  </template>
 </Experiment>
 ```
 
@@ -52,7 +48,7 @@ Besides the `screens` slot, the Experiment component also provides an optional `
   <template #title>
     My experiment
   </template>
-  <template #screens>
+  <template #default>
     <Screen>
       blue
       <button @click="$magpie.nextScreen()">next</button>
@@ -222,12 +218,12 @@ export default {
    */
   /**
    * Place your screens inside this slot. They will be visible one after the other, like a slide show.
-   * @slot screens
+   * @slot default
    */
   render(h) {
     // HACKY-O
     this.$parent.$magpie = this.magpie;
-    const children = this.$slots.screens;
+    const children = this.$slots.default;
     const screens = children.filter((c) => !!c.componentOptions);
     return h('div', { class: 'experiment' + (this.wide ? ' wide' : '') }, [
       h('div', { class: 'header' }, [

--- a/src/components/Slide.vue
+++ b/src/components/Slide.vue
@@ -1,0 +1,9 @@
+<template>
+  <div><slot name="default"></slot></div>
+</template>
+
+<script>
+export default {
+  name: 'Slide'
+};
+</script>


### PR DESCRIPTION
Based on feedback from yesterday's presentation, I've tried to come up with a more intuitive interface for using slides:

Before:

```vue
<Experiment>
  <template #screens>

    <Screen title="Wow.">

      <template #0="{ nextSlide }">
        <Wait :time="2000" @done="nextSlide" />
      </template>

      <template #1="{measurements, saveAndNextScreen}">
        Hello
        <TextareaInput :response.sync="measurements.text" />
        {{ measurements.text }}?
        <button v-if="measurements.text" @click="saveAndNextScreen()">Done</button>
      </template>

    </Screen>

    <DebugResultsScreen />

  </template>
</Experiment>
```

After:

```vue
<Experiment>

    <Screen title="Wow.">

      <Slide>
        <Wait :time="2000" @done="$magpie.nextSlide" />
      </Slide>

      <Slide>
        Hello
        <TextareaInput :response.sync="$magpie.measurements.text" />
        {{ $magpie.measurements.text }}?
        <button v-if="$magpie.measurements.text" @click="$magpie.saveAndNextScreen()">Done</button>
      </Slide>

    </Screen>

    <DebugResultsScreen />

</Experiment>
```

Another benefit besides the simpler API, is the opportunity to create read-made slides, like a FixationCrossSlide:


```vue
<Experiment>

    <Screen title="Wow.">

      <FixationCrossSlide :time="1500">

      <Slide>
        Hello
        <TextareaInput :response.sync="$magpie.measurements.text" />
        {{ $magpie.measurements.text }}?
        <button v-if="$magpie.measurements.text" @click="$magpie.saveAndNextScreen()">Done</button>
      </Slide>

    </Screen>

    <DebugResultsScreen />

</Experiment>
```