### PR TITLE
LifecycleScreen: Automatically set response_timeout boolean if responseTime is set

### DIFF
--- a/src/components/screens/LifecycleScreen.vue
+++ b/src/components/screens/LifecycleScreen.vue
@@ -71,14 +71,11 @@ The last four phases can be completely customized using the corresponding slots,
       <p v-if="qud" v-text="qud"></p>
       <slot v-if="!stimulusTime" name="stimulus"></slot>
       <slot name="task"></slot>
-      <Wait
-        v-if="responseTime"
-        :time="responseTime"
-        @done="$magpie.nextSlide()"
-      />
+      <Wait v-if="responseTime" :time="responseTime" @done="nextAfterTimeout" />
       <Record
         :data="{
-          qud
+          qud,
+          ...(responseTime && { response_timeout: false })
         }"
       />
       <ResponseTimeStart />
@@ -144,7 +141,8 @@ export default {
       default: 0
     },
     /**
-     * How long the response should be enabled, don't set this, to avoid the timeout altogether
+     * How long the response should be enabled, don't set this, to avoid the timeout altogether.
+     * When this is set, a `response_timeout` boolean property will be added to the result, indicating whether timeout occurred
      */
     responseTime: {
       type: Number,
@@ -166,6 +164,12 @@ export default {
       } else {
         this.$magpie.saveAndNextScreen();
       }
+    },
+    nextAfterTimeout() {
+      if (this.$props.responseTime) {
+        this.$magpie.measurements.response_timeout = true;
+      }
+      this.nextAfterResponse();
     }
   }
 };

--- a/tests/unit/screens/LifecycleScreen.spec.js
+++ b/tests/unit/screens/LifecycleScreen.spec.js
@@ -25,6 +25,57 @@ test('LifecycleScreen', async () => {
     const results = experiment.vm.$magpie.getAllData()
     expect(results).toBeInstanceOf(Array)
     expect(results).toHaveLength(1)
+    expect(results[0].response_timeout).toBeUndefined()
+})
+
+test('LifecycleScreen with response time', async () => {
+    const experiment = mount(Experiment, {
+        slots: {
+            default: [
+                '<LifecycleScreen :responseTime="500">' +
+                '<template #task>' +
+                '<button @click="$magpie.saveAndNextScreen()">Click here</button>' +
+                '</template>' +
+                '</LifecycleScreen>',
+                '<Screen>Bye world</Screen>',
+            ]
+        }
+    })
+
+    expect(experiment.text()).toBe('Click here')
+
+    await experiment.find('button').trigger('click')
+
+    expect(experiment.text()).toBe('Bye world')
+    const results = experiment.vm.$magpie.getAllData()
+    expect(results).toBeInstanceOf(Array)
+    expect(results).toHaveLength(1)
+    expect(results[0].response_timeout).toEqual(false)
+})
+
+test('LifecycleScreen with response time', async () => {
+    const experiment = mount(Experiment, {
+        slots: {
+            default: [
+                '<LifecycleScreen :responseTime="500">' +
+                '<template #task>' +
+                '<button @click="$magpie.saveAndNextScreen()">Click here</button>' +
+                '</template>' +
+                '</LifecycleScreen>',
+                '<Screen>Bye world</Screen>',
+            ]
+        }
+    })
+
+    expect(experiment.text()).toBe('Click here')
+
+    await new Promise(resolve => setTimeout(resolve, 500))
+
+    expect(experiment.text()).toBe('Bye world')
+    const results = experiment.vm.$magpie.getAllData()
+    expect(results).toBeInstanceOf(Array)
+    expect(results).toHaveLength(1)
+    expect(results[0].response_timeout).toEqual(true)
 })
 
 test('LifecycleScreen with pause', async () => {


### PR DESCRIPTION
This adds a `response_timeout` boolean variable to the results of all built-in trial screens when the responseTime prop is set. This variable will be `true` if the responseTime was reached, otherwise it will be `false`.

This also fixes the bug where a timed out trial wasn't recorded at all.