### PR TITLE
Experiment component: Add record prop for declaratively recording expData

### DIFF
--- a/src/components/Experiment.vue
+++ b/src/components/Experiment.vue
@@ -87,6 +87,13 @@ export default {
       type: String,
       default: ''
     },
+    /**
+     * Optionally specify variables that should be recorded for the whole experiment
+     */
+    recordData: {
+      type: Object,
+      default: () => ({})
+    },
 
     /**
      * Pass an array of paths to images that will be needed in this experiment to enable preloading
@@ -158,6 +165,8 @@ export default {
       preloadLink.as = 'video';
       document.head.appendChild(preloadLink);
     });
+
+    this.$magpie.addExpData(this.recordData);
 
     // Ask the user before closing the page
     window.addEventListener('beforeunload', (e) => {

--- a/src/components/helpers/Record.vue
+++ b/src/components/helpers/Record.vue
@@ -31,17 +31,32 @@ import Vue from 'vue';
 export default {
   name: 'Record',
   props: {
+    /**
+     * The data you want to add
+     */
     data: {
       type: Object,
       required: true
+    },
+    /**
+     * If you set the global prop, the data will be added to the global experiment measurements instead of only to the current
+     * trial
+     */
+    global: {
+      type: Boolean,
+      default: false
     }
   },
   mounted() {
-    Object.keys(this.data).forEach((key) => {
-      if (typeof this.data[key] !== 'undefined') {
-        Vue.set(this.$magpie.measurements, key, this.data[key]);
-      }
-    });
+    if (this.global) {
+      this.$magpie.addExpData(this.data);
+    } else {
+      Object.keys(this.data).forEach((key) => {
+        if (typeof this.data[key] !== 'undefined') {
+          Vue.set(this.$magpie.measurements, key, this.data[key]);
+        }
+      });
+    }
   }
 };
 </script>

--- a/tests/unit/Experiment.spec.js
+++ b/tests/unit/Experiment.spec.js
@@ -28,6 +28,26 @@ test('Two-screen Experiment', async () => {
     expect(experiment.text()).toBe('Bye World')
 })
 
+test('Two-Screen Experiment with record data', async () => {
+    const experiment = mount(Experiment, {
+        attrs: {
+            recordData: { foo: 'bar' },
+        },
+        slots: {
+            default: [
+                '<Screen>Hello World</Screen>',
+                '<Screen>Bye World</Screen>',
+            ]
+        }
+    })
+
+    expect(experiment.text()).toBe('Hello World')
+    experiment.vm.$magpie.saveAndNextScreen()
+    const results = experiment.vm.$magpie.getAllData()
+    expect(results).toHaveLength(1)
+    expect(results[0].foo).toEqual('bar')
+})
+
 test('Many-screen Experiment', async () => {
     const experiment = mount(Experiment, {
         slots: {

--- a/tests/unit/helpers/Record.spec.js
+++ b/tests/unit/helpers/Record.spec.js
@@ -1,0 +1,44 @@
+import { mount } from '@vue/test-utils'
+import Vue from 'vue'
+import Experiment from "@/components/Experiment";
+
+test('Manually record data', async () => {
+    const experiment = mount(Experiment, {
+        slots: {
+            default: [
+                '<Screen>Hello World<Record :data="{foo: \'bar\'}" /></Screen>',
+                '<Screen>Bye World</Screen>',
+            ]
+        }
+    })
+
+    expect(experiment.text()).toBe('Hello World')
+    experiment.vm.$magpie.saveAndNextScreen()
+    const results = experiment.vm.$magpie.getAllData()
+    expect(results).toHaveLength(1)
+    expect(results[0].foo).toEqual('bar')
+})
+
+
+test('Manually record global data', async () => {
+    const experiment = mount(Experiment, {
+        slots: {
+            default: [
+                '<Screen>Hello World<Record global :data="{foo: \'bar\'}" /></Screen>',
+                '<Screen>Bye World</Screen>',
+                '<Screen>Good bye</Screen>',
+            ]
+        }
+    })
+
+    expect(experiment.text()).toBe('Hello World')
+    experiment.vm.$magpie.saveAndNextScreen()
+    await Vue.nextTick()
+    expect(experiment.text()).toBe('Bye World')
+    experiment.vm.$magpie.saveAndNextScreen()
+    await Vue.nextTick()
+    const results = experiment.vm.$magpie.getAllData()
+    expect(results).toHaveLength(2)
+    expect(results[0].foo).toEqual('bar')
+    expect(results[1].foo).toEqual('bar')
+})


### PR DESCRIPTION
This PR allows declaring experiment-wide data using a prop on the Experiment component...

```vue
<Experiment :recordData="{ group: group }">

// ...

</Experiment>
```

It also adds a `global` flag to the Record component to allow declaring experiment-wide data in the midst of a trial

```vue
<Record global :data="{ group: group }" />
```